### PR TITLE
Support for [link] and quoted attributes [url="http://"]link[/url]

### DIFF
--- a/lib/bbcode.js
+++ b/lib/bbcode.js
@@ -24,6 +24,7 @@
 //
 // [url]http://blogs.stonesteps.ca/showpost.asp?pid=33[/url]
 // [url=http://blogs.stonesteps.ca/showpost.asp?pid=33][b]BBCode[/b] Parser[/url]
+// [url="http://blogs.stonesteps.ca/showpost.asp?pid=33"][b]BBCode[/b] Parser[/url]
 //
 // [q=http://blogs.stonesteps.ca/showpost.asp?pid=33]inline quote[/q]
 // [q]inline quote[/q]
@@ -50,7 +51,7 @@ exports.parse = function(post, cb) {
   var urlstart = -1;      // beginning of the URL if zero or greater (ignored if -1)
 
   // aceptable BBcode tags, optionally prefixed with a slash
-  var tagname_re = /^\/?(?:b|i|u|pre|samp|code|colou?r|size|noparse|url|s|q|blockquote|img|u?list|li)$/;
+  var tagname_re = /^\/?(?:b|i|u|pre|samp|code|colou?r|size|noparse|url|link|s|q|blockquote|img|u?list|li)$/;
 
   // color names or hex color
   var color_re = /^(:?black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|aqua|#(?:[0-9a-f]{3})?[0-9a-f]{3})$/i;
@@ -61,8 +62,8 @@ exports.parse = function(post, cb) {
   // reserved, unreserved, escaped and alpha-numeric [RFC2396]
   var uri_re = /^[-;\/\?:@&=\+\$,_\.!~\*'\(\)%0-9a-z]{1,512}$/i;
 
-  // main regular expression: CRLF, [tag=option], [tag] or [/tag]
-  var postfmt_re = /([\r\n])|(?:\[([a-z]{1,16})(?:=([^\x00-\x1F"'\(\)<>\[\]]{1,256}))?\])|(?:\[\/([a-z]{1,16})\])/ig;
+  // main regular expression: CRLF, [tag=option], [tag="option"] [tag] or [/tag]
+  var postfmt_re = /([\r\n])|(?:\[([a-z]{1,16})(?:=(?:"|'|)([^\x00-\x1F"'\(\)<>\[\]]{1,256}))?(?:"|'|)\])|(?:\[\/([a-z]{1,16})\])/ig;
 
   // stack frame object
   function taginfo_t(bbtag, etag)
@@ -114,7 +115,7 @@ exports.parse = function(post, cb) {
         return "[" + m2 + "]";
 
       // ignore any tags if there's an open option-less [url] tag
-      if(opentags.length && opentags[opentags.length-1].bbtag == "url" && urlstart >= 0)
+      if(opentags.length && (opentags[opentags.length-1].bbtag == "url" || opentags[opentags.length-1].bbtag == "link") && urlstart >= 0)
         return "[" + m2 + "]";
 
       switch (m2) {
@@ -149,6 +150,7 @@ exports.parse = function(post, cb) {
           noparse = true;
           return "";
 
+        case "link":
         case "url":
           opentags.push(new taginfo_t(m2, "</a>"));
 
@@ -214,7 +216,7 @@ exports.parse = function(post, cb) {
       if(!opentags.length || opentags[opentags.length-1].bbtag != m4)
         return "<span style=\"color: red\">[/" + m4 + "]</span>";
 
-      if(m4 == "url") {
+      if(m4 == "url" || m4 == "link") {
         // if there was no option, use the content of the [url] tag
         if(urlstart > 0)
           return "\">" + string.substr(urlstart, offset-urlstart) + opentags.pop().etag;
@@ -262,7 +264,7 @@ exports.parse = function(post, cb) {
       endtags = new String();
 
       // if there's an open [url] at the top, close it
-      if(opentags[opentags.length-1].bbtag == "url") {
+      if(opentags[opentags.length-1].bbtag == "url" || opentags[opentags.length-1].bbtag == "link") {
         opentags.pop();
         endtags += "\">" + post.substr(urlstart, post.length-urlstart) + "</a>";
       }

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -57,15 +57,59 @@ describe('bcrypt', function() {
       });
     });
 
-    it('should parse [url=<url>] to <a href=<url>>', function() {
-      bbcode.parse('[url=http://example.com]url[/url]', function(parse) {
-        parse.should.equal('<a href="http://example.com">url</a>');
+    describe('should parse [url] and [link]', function() {
+      it('should parse [url=<url>] to <a href=<url>>', function() {
+        bbcode.parse('[url=http://example.com]url[/url]', function(parse) {
+          parse.should.equal('<a href="http://example.com">url</a>');
+        });
+      });
+
+      it('should parse [url="<url>"] to <a href=<url>>', function() {
+        bbcode.parse('[url="http://example.com"]url[/url]', function(parse) {
+          parse.should.equal('<a href="http://example.com">url</a>');
+        });
+      });
+
+      it('should parse [url=\'<url>\'] to <a href=<url>>', function() {
+        bbcode.parse('[url=\'http://example.com\']url[/url]', function(parse) {
+          parse.should.equal('<a href="http://example.com">url</a>');
+        });
+      });
+
+      it('should parse [link=<url>]test[/link]', function() {
+        bbcode.parse('[link=http://example.com]url[/link]', function(parse) {
+          parse.should.equal('<a href="http://example.com">url</a>');
+        });
+      });
+
+      it('should parse [link="<url>"]test[/link]', function() {
+        bbcode.parse('[link="http://example.com"]url[/link]', function(parse) {
+          parse.should.equal('<a href="http://example.com">url</a>');
+        });
+      });
+
+      it('should parse [link=\'<url>\']test[/link]', function() {
+        bbcode.parse('[link=\'http://example.com\']url[/link]', function(parse) {
+          parse.should.equal('<a href="http://example.com">url</a>');
+        });
       });
     });
 
     describe('should parse [img]', function() {
       it('as attribute - [img=<img>] to <img src=<img>>', function() {
         bbcode.parse('[img=http://example.com/img.png][/img]', function(parse) {
+          parse.should.equal('<img src="http://example.com/img.png" />');
+        });
+      });
+
+      it('as attribute with quotes - [img="<img>"] to <img src=<img>>', function() {
+        bbcode.parse('[img="http://example.com/img.png"][/img]', function(parse) {
+          parse.should.equal('<img src="http://example.com/img.png" />');
+        });
+      });
+
+      it('as attribute with single quotes - [img=\'<img>\'] to <img src=<img>>', function() {
+        bbcode.parse('[img=\'http://example.com/img.png\'][/img]', function(parse) {
           parse.should.equal('<img src="http://example.com/img.png" />');
         });
       });


### PR DESCRIPTION
This commit is to add full support for [link] as an alias of [url], single-quoted attributes, and double-quoted attributes. I've added test cases for each of my additions and all tests pass.

Thank you.
