### PR TITLE
Add support for upper and mixed-case bbcode tags

### DIFF
--- a/lib/bbcode.js
+++ b/lib/bbcode.js
@@ -1,14 +1,14 @@
 // -----------------------------------------------------------------------
-// Copyright (c) 2008, Stone Steps Inc. 
+// Copyright (c) 2008, Stone Steps Inc.
 // All rights reserved
 // http://www.stonesteps.ca/legal/bsd-license/
 //
 // This is a BBCode parser written in JavaScript. The parser is intended
-// to demonstrate how to parse text containing BBCode tags in one pass 
+// to demonstrate how to parse text containing BBCode tags in one pass
 // using regular expressions.
 //
-// The parser may be used as a backend component in ASP or in the browser, 
-// after the text containing BBCode tags has been served to the client. 
+// The parser may be used as a backend component in ASP or in the browser,
+// after the text containing BBCode tags has been served to the client.
 //
 // Following BBCode expressions are recognized:
 //
@@ -31,9 +31,9 @@
 // [blockquote=http://blogs.stonesteps.ca/showpost.asp?pid=33]block quote[/blockquote]
 // [blockquote]block quote[/blockquote]
 //
-// [pre]formatted 
+// [pre]formatted
 //     text[/pre]
-// [code]if(a == b) 
+// [code]if(a == b)
 //   print("done");[/code]
 //
 // text containing [noparse] [brackets][/noparse]
@@ -51,7 +51,7 @@ exports.parse = function(post, cb) {
   var urlstart = -1;      // beginning of the URL if zero or greater (ignored if -1)
 
   // aceptable BBcode tags, optionally prefixed with a slash
-  var tagname_re = /^\/?(?:b|i|u|pre|samp|code|colou?r|size|noparse|url|link|s|q|blockquote|img|u?list|li)$/;
+  var tagname_re = /^\/?(?:b|i|u|pre|samp|code|colou?r|size|noparse|url|link|s|q|blockquote|img|u?list|li)$/i;
 
   // color names or hex color
   var color_re = /^(:?black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|aqua|#(?:[0-9a-f]{3})?[0-9a-f]{3})$/i;
@@ -110,6 +110,8 @@ exports.parse = function(post, cb) {
     // handle start tags
     //
     if(isValidTag(m2)) {
+      var m2l = m2.toLowerCase();
+
       // if in the noparse state, just echo the tag
       if(noparse)
         return "[" + m2 + "]";
@@ -118,14 +120,14 @@ exports.parse = function(post, cb) {
       if(opentags.length && (opentags[opentags.length-1].bbtag == "url" || opentags[opentags.length-1].bbtag == "link") && urlstart >= 0)
         return "[" + m2 + "]";
 
-      switch (m2) {
+      switch (m2l) {
         case "code":
-          opentags.push(new taginfo_t(m2, "</code></pre>"));
+          opentags.push(new taginfo_t(m2l, "</code></pre>"));
           crlf2br = false;
           return "<pre><code>";
 
         case "pre":
-          opentags.push(new taginfo_t(m2, "</pre>"));
+          opentags.push(new taginfo_t(m2l, "</pre>"));
           crlf2br = false;
           return "<pre>";
 
@@ -133,17 +135,17 @@ exports.parse = function(post, cb) {
         case "colour":
           if(!m3 || !color_re.test(m3))
             m3 = "inherit";
-          opentags.push(new taginfo_t(m2, "</span>"));
+          opentags.push(new taginfo_t(m2l, "</span>"));
           return "<span style=\"color: " + m3 + "\">";
 
         case "size":
           if(!m3 || !number_re.test(m3))
             m3 = "1";
-          opentags.push(new taginfo_t(m2, "</span>"));
+          opentags.push(new taginfo_t(m2l, "</span>"));
           return "<span style=\"font-size: " + Math.min(Math.max(m3, 0.7), 3) + "em\">";
 
         case "s":
-          opentags.push(new taginfo_t(m2, "</span>"));
+          opentags.push(new taginfo_t(m2l, "</span>"));
           return "<span style=\"text-decoration: line-through\">";
 
         case "noparse":
@@ -152,7 +154,7 @@ exports.parse = function(post, cb) {
 
         case "link":
         case "url":
-          opentags.push(new taginfo_t(m2, "</a>"));
+          opentags.push(new taginfo_t(m2l, "</a>"));
 
           // check if there's a valid option
           if(m3 && uri_re.test(m3)) {
@@ -161,25 +163,25 @@ exports.parse = function(post, cb) {
             return "<a target=\"_blank\" href=\"" + m3 + "\">";
           }
 
-          // otherwise, remember the URL offset 
+          // otherwise, remember the URL offset
           urlstart = mstr.length + offset;
 
           // and treat the text following [url] as a URL
           return "<a target=\"_blank\" href=\"";
         case "img":
-          opentags.push(new taginfo_t(m2, "\" />"));
+          opentags.push(new taginfo_t(m2l, "\" />"));
 
           if (m3  && uri_re.test(m3)) {
             urlstart = -1;
-            return "<" + m2 + " src=\"" + m3 + "";
+            return "<" + m2l + " src=\"" + m3 + "";
           }
 
-          return "<"+m2+" src=\"";
+          return "<"+m2l+" src=\"";
 
         case "q":
         case "blockquote":
-          opentags.push(new taginfo_t(m2, "</" + m2 + ">"));
-          return m3 && m3.length && uri_re.test(m3) ? "<" + m2 + " cite=\"" + m3 + "\">" : "<" + m2 + ">";
+          opentags.push(new taginfo_t(m2l, "</" + m2l + ">"));
+          return m3 && m3.length && uri_re.test(m3) ? "<" + m2l + " cite=\"" + m3 + "\">" : "<" + m2l + ">";
 
         case "list":
           opentags.push(new taginfo_t('list', '</ol>'));
@@ -188,19 +190,19 @@ exports.parse = function(post, cb) {
         case "ulist":
           opentags.push(new taginfo_t('ulist', '</ul>'));
           return '<ul>';
-          
+
         case "b":
           opentags.push(new taginfo_t('b', '</strong>'));
           return '<strong>';
-          
+
         case "i":
           opentags.push(new taginfo_t('i', '</em>'));
           return '<em>';
 
         default:
           // [samp] and [u] don't need special processing
-          opentags.push(new taginfo_t(m2, "</" + m2 + ">"));
-          return "<" + m2 + ">";
+          opentags.push(new taginfo_t(m2l, "</" + m2l + ">"));
+          return "<" + m2l + ">";
 
       }
     }
@@ -209,6 +211,8 @@ exports.parse = function(post, cb) {
     // process end tags
     //
     if(isValidTag(m4)) {
+      var m4l = m4.toLowerCase();
+
       if(noparse) {
         // if it's the closing noparse tag, flip the noparse state
         if(m4 == "noparse")  {
@@ -221,10 +225,10 @@ exports.parse = function(post, cb) {
       }
 
       // highlight mismatched end tags
-      if(!opentags.length || opentags[opentags.length-1].bbtag != m4)
+      if(!opentags.length || opentags[opentags.length-1].bbtag != m4l)
         return "<span style=\"color: red\">[/" + m4 + "]</span>";
 
-      if(m4 == "url" || m4 == "link") {
+      if(m4l == "url" || m4l == "link") {
         // if there was no option, use the content of the [url] tag
         if(urlstart > 0)
           return "\">" + string.substr(urlstart, offset-urlstart) + opentags.pop().etag;
@@ -232,7 +236,7 @@ exports.parse = function(post, cb) {
         // otherwise just close the tag
         return opentags.pop().etag;
       }
-      else if(m4 == "code" || m4 == "pre")
+      else if(m4l == "code" || m4l == "pre")
         crlf2br = true;
 
       // other tags require no special processing, just output the end tag

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -189,5 +189,23 @@ describe('bcrypt', function() {
       var parse = bbcode.parse('[b][i][u]Hai[/u][/i][/b]');
       parse.should.equal('<strong><em><u>Hai</u></em></strong>');
     });
+
+    describe('should parse uppercase tags properly - ', function() {
+      it('should parse uppercase [I] to <em>', function() {
+        bbcode.parse('[I]italics[/I]', function(parse) {
+          parse.should.equal('<em>italics</em>');
+        });
+      });
+      it('should parse uppercase [IMG] to <img>', function() {
+        bbcode.parse('[IMG]http://example.com/img.png[/IMG]', function(parse) {
+          parse.should.equal('<img src="http://example.com/img.png" />');
+        });
+      });
+      it('should parse mixed case [IMG][/img] to <img>', function() {
+        bbcode.parse('[Img]http://example.com/img.png[/img]', function(parse) {
+          parse.should.equal('<img src="http://example.com/img.png" />');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
The current parser only handles fully lowercase bbcode tags. This change
augments the existing functionality to essentially make the bbcode tag
detection case insensitive, for cases where you may have upper or
mixed-cased tags in your source content.

I'm not enough of a bbcode expert to know whether upper/mixed case tags are 'legal', but I have some source content with that formatting, and so needed these changes in order to make the module fully compatible for my purposes. Hopefully you find the change useful and want to pull it back into your master copy.

I also added a few quick tests to verify all is working well.

Let me know if you have any questions.

Dan
