### PR TITLE
center tag

### DIFF
--- a/lib/bbcode.js
+++ b/lib/bbcode.js
@@ -51,7 +51,7 @@ exports.parse = function(post, cb) {
   var urlstart = -1;      // beginning of the URL if zero or greater (ignored if -1)
 
   // aceptable BBcode tags, optionally prefixed with a slash
-  var tagname_re = /^\/?(?:b|i|u|pre|samp|code|colou?r|size|noparse|url|link|s|q|blockquote|img|u?list|li)$/i;
+  var tagname_re = /^\/?(?:b|i|u|pre|center|samp|code|colou?r|size|noparse|url|link|s|q|blockquote|img|u?list|li)$/i;
 
   // color names or hex color
   var color_re = /^(:?black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|aqua|#(?:[0-9a-f]{3})?[0-9a-f]{3})$/i;
@@ -130,6 +130,11 @@ exports.parse = function(post, cb) {
           opentags.push(new taginfo_t(m2l, "</pre>"));
           crlf2br = false;
           return "<pre>";
+
+        case "center":
+          opentags.push(new taginfo_t(m2l, "</center>"));
+          crlf2br = false;
+          return "<center>";
 
         case "color":
         case "colour":

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -34,6 +34,12 @@ describe('bcrypt', function() {
       });
     });
 
+    it('should parse [center] to <center>', function() {
+      bbcode.parse('[center]Center[/center]', function(parse) {
+        parse.should.equal('<center>Center</center>');
+      });
+    });
+
     it('should parse [color] to <span style="color:<color>"> for all colors', function() {
       var colors = ['black', 'silver', 'gray', 'maroon', 'white', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', '#fff', '#ffffff', '#ff34ff'];
 


### PR DESCRIPTION
<center></center> is deprecated in HTML5, but as many BBCode files use this tag frequently it should be supported. Replacing [center][/center] with something else like <p style="text-align: center"></p> looks like an overkill to me.
