### PR TITLE
Add support for [quote] element

### DIFF
--- a/lib/bbcode.js
+++ b/lib/bbcode.js
@@ -28,6 +28,8 @@
 //
 // [q=http://blogs.stonesteps.ca/showpost.asp?pid=33]inline quote[/q]
 // [q]inline quote[/q]
+// [quote=http://blogs.stonesteps.ca/showpost.asp?pid=33]inline quote[/quote]
+// [quote]inline quote[/quote]
 // [blockquote=http://blogs.stonesteps.ca/showpost.asp?pid=33]block quote[/blockquote]
 // [blockquote]block quote[/blockquote]
 //
@@ -51,7 +53,7 @@ exports.parse = function(post, cb) {
   var urlstart = -1;      // beginning of the URL if zero or greater (ignored if -1)
 
   // aceptable BBcode tags, optionally prefixed with a slash
-  var tagname_re = /^\/?(?:b|i|u|pre|center|samp|code|colou?r|size|noparse|url|link|s|q|blockquote|img|u?list|li)$/i;
+  var tagname_re = /^\/?(?:b|i|u|pre|center|samp|code|colou?r|size|noparse|url|link|s|q|(block)?quote|img|u?list|li)$/i;
 
   // color names or hex color
   var color_re = /^(:?black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|aqua|#(?:[0-9a-f]{3})?[0-9a-f]{3})$/i;
@@ -184,9 +186,11 @@ exports.parse = function(post, cb) {
           return "<"+m2l+" src=\"";
 
         case "q":
+        case "quote":
         case "blockquote":
-          opentags.push(new taginfo_t(m2l, "</" + m2l + ">"));
-          return m3 && m3.length && uri_re.test(m3) ? "<" + m2l + " cite=\"" + m3 + "\">" : "<" + m2l + ">";
+          var tag = (m2l === "q") ? "q" : "blockquote";
+          opentags.push(new taginfo_t(m2l, "</" + tag + ">"));
+          return m3 && m3.length && uri_re.test(m3) ? "<" + tag + " cite=\"" + m3 + "\">" : "<" + tag + ">";
 
         case "list":
           opentags.push(new taginfo_t('list', '</ol>'));

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -139,6 +139,12 @@ describe('bcrypt', function() {
       });
     });
 
+    it('should parse [quote] as <blockquote>', function() {
+      bbcode.parse('[quote=person]quoted[/quote]', function(parse) {
+        parse.should.equal('<blockquote cite="person">quoted</blockquote>');
+      });
+    });
+
     it('should try to fix broken markup', function() {
       bbcode.parse('[b]test', function(parse) {
         parse.should.equal('<strong>test</strong>');


### PR DESCRIPTION
Some implementations of bbcode utilize the [quote] tag, instead of/in
addition to [blockquote]. This commit adds support for [quote], and
treats it the same as [blockquote].

http://bbcode.org/reference.php

Let me know if you have any issues with the change. If you want to incorporate it, it'd be great if you could bump versions and publish to npm!
